### PR TITLE
fix $_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.2
+
+### Fixed
+
+-  Fixed `$_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']` for roadrunner worker.
+
 ## v1.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## v1.1.2
+## v1.2.0
 
-### Fixed
-
--  Fixed `$_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']` for roadrunner worker.
+### Added
+- Support option `--(not-)reset-debug-info`
 
 ## v1.1.1
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you wants to disable package service-provider auto discover, just add into yo
 `--(not-)reset-db-connections` | Обрывает (или нет) соединения с БД после обработки входящего запроса
 `--(not-)reset-redis-connections` | Обрывает (или нет) соединения с redis после обработки входящего запроса
 `--(not-)refresh-app` | Принудительно пересоздает инстанс приложения после обработки **каждого** запроса
+`--(not-)reset-debug-info` | Устанавливает переменные `$_SERVER['LARAVEL_START_TIME']`, `$_SERVER['LARAVEL_START_MEMORY']` на актуальные значение перед обработкой http-запроса.
 
 > Параметры запуска указываются в файле-конфигурации (например: `./.rr.local.yml`) по пути `http.workers.command`, например: `php ./vendor/bin/rr-worker --some-parameter`
 

--- a/configs/rr/.rr.local.yml
+++ b/configs/rr/.rr.local.yml
@@ -43,6 +43,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
+    # - `--(not-)reset-debug-info`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.yml
+++ b/configs/rr/.rr.yml
@@ -43,6 +43,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
+    # - `--(not-)reset-debug-info`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -134,7 +134,7 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     {
         if ($value === true) {
             $callbacks->beforeLoopIterationStack()
-                ->push(function (Application $app, ServerRequestInterface $request) {
+                ->push(function (Application $app) {
                     $_SERVER['LARAVEL_START_TIME']   = microtime(true);
                     $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
                 });

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -123,6 +123,25 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
+     * For option "--reset-debug-info"
+     *
+     * @param CallbacksInterface $callbacks
+     * @param bool|mixed         $value
+     *
+     * @return void
+     */
+    protected function initResetDebugInfo(CallbacksInterface $callbacks, $value)
+    {
+        if ($value === true) {
+            $callbacks->beforeLoopIterationStack()
+                ->push(function (Application $app, ServerRequestInterface $request) {
+                    $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                    $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+                });
+        }
+    }
+
+    /**
      * For option: "--reset-db-connections".
      *
      * @param CallbacksInterface $callbacks

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -123,7 +123,7 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
-     * For option "--reset-debug-info"
+     * For option "--reset-debug-info".
      *
      * @param CallbacksInterface $callbacks
      * @param bool|mixed         $value
@@ -133,11 +133,10 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     protected function initResetDebugInfo(CallbacksInterface $callbacks, $value)
     {
         if ($value === true) {
-            $callbacks->beforeLoopIterationStack()
-                ->push(function (Application $app) {
-                    $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-                    $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-                });
+            $callbacks->beforeLoopIterationStack()->push(function (Application $app) {
+                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+            });
         }
     }
 

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -93,12 +93,6 @@ class Worker implements WorkerInterface
 
         // Initialize callbacks, based on start options
         $initializer->makeInit();
-
-        // Fixed start time and memory usage
-        $this->callbacks()->beforeLoopIterationStack()->push(function () {
-            $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-            $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-        });
     }
 
     /**

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -154,6 +154,9 @@ class Worker implements WorkerInterface
 
         while ($req = $this->psr7_client->acceptRequest()) {
             try {
+                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+
                 $this->callbacks->beforeLoopIterationStack()->callEach($this->app, $req);
 
                 $request = Request::createFromBase($this->http_factory->createRequest($req));

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -93,6 +93,12 @@ class Worker implements WorkerInterface
 
         // Initialize callbacks, based on start options
         $initializer->makeInit();
+
+        // Fixed start time and memory usage
+        $this->callbacks()->beforeLoopIterationStack()->push(function () {
+            $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+            $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+        });
     }
 
     /**
@@ -154,9 +160,6 @@ class Worker implements WorkerInterface
 
         while ($req = $this->psr7_client->acceptRequest()) {
             try {
-                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-
                 $this->callbacks->beforeLoopIterationStack()->callEach($this->app, $req);
 
                 $request = Request::createFromBase($this->http_factory->createRequest($req));

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -240,7 +240,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     public function testResetDebugInfoWithPassingTrue()
     {
         $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, true]);
-        $closure = $this->callbacks->afterLoopIterationStack()->first();
+        $closure = $this->callbacks->beforeLoopIterationStack()->first();
         $closure($this->app); // Test direct calling
         $this->assertInstanceOf(\Closure::class, $closure);
     }
@@ -251,7 +251,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     public function testResetDebugInfoWithPassingFalse()
     {
         $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, false]);
-        $this->assertEmpty($this->callbacks->afterLoopIterationStack());
+        $this->assertEmpty($this->callbacks->beforeLoopIterationStack());
     }
 
     /**

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -237,6 +237,26 @@ class CallbacksInitializerTest extends AbstractTestCase
     /**
      * @return void
      */
+    public function testResetDebugInfoWithPassingTrue()
+    {
+        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, true]);
+        $closure = $this->callbacks->afterLoopIterationStack()->first();
+        $closure($this->app); // Test direct calling
+        $this->assertInstanceOf(\Closure::class, $closure);
+    }
+
+    /**
+     * @return void
+     */
+    public function testResetDebugInfoWithPassingFalse()
+    {
+        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, false]);
+        $this->assertEmpty($this->callbacks->afterLoopIterationStack());
+    }
+
+    /**
+     * @return void
+     */
     public function testResetRedisConnectionsWithPassingTrue()
     {
         $this->callMethod($this->initializer, 'initResetRedisConnections', [$this->callbacks, true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No 
| New feature?  | Yes

## Description

> Fixed `$_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']` for roadrunner worker.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

