### PR TITLE
Add laravel start data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ## v1.2.0
 
 ### Added
-- Support option `--(not-)reset-debug-info`
+
+- Worker option `--(not-)update-app-stats` for updating in IoC containers timestamp and allocated memory size before each incoming request processing
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.2
+
+### Fixed
+
+-  Fixed `$_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']` for roadrunner worker.
+
 ## v1.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## v1.1.2
+## v1.2.0
 
-### Fixed
-
--  Fixed `$_SERVER['LARAVEL_START_TIME']` and `$_SERVER['LARAVEL_START_MEMORY']` for roadrunner worker.
+### Added
+- Support option `--(not-)reset-debug-info`
 
 ## v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Worker option `--(not-)update-app-stats` for updating in IoC containers timestamp and allocated memory size before each incoming request processing
+- Worker option `--(not-)inject-stats-into-request` for injecting macroses into request object for accessing timestamp and allocated memory size (before request processing) values
 
 ## v1.1.1
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Easy way for connecting [RoadRunner][roadrunner] and Laravel applications.
 Require this package with composer using the following command:
 
 ```shell
-$ composer require avto-dev/roadrunner-laravel "^1.0"
+$ composer require avto-dev/roadrunner-laravel "^1.2"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]).
@@ -58,7 +58,7 @@ If you wants to disable package service-provider auto discover, just add into yo
 `--(not-)reset-db-connections` | Обрывает (или нет) соединения с БД после обработки входящего запроса
 `--(not-)reset-redis-connections` | Обрывает (или нет) соединения с redis после обработки входящего запроса
 `--(not-)refresh-app` | Принудительно пересоздает инстанс приложения после обработки **каждого** запроса
-`--(not-)reset-debug-info` | Устанавливает переменные `$_SERVER['LARAVEL_START_TIME']`, `$_SERVER['LARAVEL_START_MEMORY']` на актуальные значение перед обработкой http-запроса.
+`--(not-)update-app-stats` | Обновляет в сервис-контейнерах приложения значения временной метки (`REQUEST_PROCESSING_START_TIME`) и использованной памяти (`REQUEST_PROCESSING_ALLOCATED_MEMORY`) **перед** обработкой каждого входящего запроса
 
 > Параметры запуска указываются в файле-конфигурации (например: `./.rr.local.yml`) по пути `http.workers.command`, например: `php ./vendor/bin/rr-worker --some-parameter`
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you wants to disable package service-provider auto discover, just add into yo
 `--(not-)reset-db-connections` | Обрывает (или нет) соединения с БД после обработки входящего запроса
 `--(not-)reset-redis-connections` | Обрывает (или нет) соединения с redis после обработки входящего запроса
 `--(not-)refresh-app` | Принудительно пересоздает инстанс приложения после обработки **каждого** запроса
+`--(not-)reset-debug-info` | Устанавливает переменные `$_SERVER['LARAVEL_START_TIME']`, `$_SERVER['LARAVEL_START_MEMORY']` на актуальные значение перед обработкой http-запроса.
 
 > Параметры запуска указываются в файле-конфигурации (например: `./.rr.local.yml`) по пути `http.workers.command`, например: `php ./vendor/bin/rr-worker --some-parameter`
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you wants to disable package service-provider auto discover, just add into yo
 `--(not-)reset-db-connections` | Обрывает (или нет) соединения с БД после обработки входящего запроса
 `--(not-)reset-redis-connections` | Обрывает (или нет) соединения с redis после обработки входящего запроса
 `--(not-)refresh-app` | Принудительно пересоздает инстанс приложения после обработки **каждого** запроса
-`--(not-)update-app-stats` | Обновляет в сервис-контейнерах приложения значения временной метки (`REQUEST_PROCESSING_START_TIME`) и использованной памяти (`REQUEST_PROCESSING_ALLOCATED_MEMORY`) **перед** обработкой каждого входящего запроса
+`--(not-)inject-stats-into-request` | **Перед** обработкой **каждого** запроса добавляет в объект `Request` макросы (`::getTimestamp()` и `::getAllocatedMemory()`), возвращающие значения временной метки и объем выделенной памяти
 
 > Параметры запуска указываются в файле-конфигурации (например: `./.rr.local.yml`) по пути `http.workers.command`, например: `php ./vendor/bin/rr-worker --some-parameter`
 

--- a/configs/rr/.rr.local.yml
+++ b/configs/rr/.rr.local.yml
@@ -47,7 +47,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
-    # - `--(not-)update-app-stats`
+    # - `--(not-)inject-stats-into-request`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.local.yml
+++ b/configs/rr/.rr.local.yml
@@ -47,7 +47,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
-    # - `--(not-)reset-debug-info`
+    # - `--(not-)update-app-stats`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.local.yml
+++ b/configs/rr/.rr.local.yml
@@ -43,6 +43,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
+    # - `--(not-)reset-debug-info`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.yml
+++ b/configs/rr/.rr.yml
@@ -47,7 +47,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
-    # - `--(not-)update-app-stats`
+    # - `--(not-)inject-stats-into-request`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.yml
+++ b/configs/rr/.rr.yml
@@ -47,7 +47,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
-    # - `--(not-)reset-debug-info`
+    # - `--(not-)update-app-stats`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.yml
+++ b/configs/rr/.rr.yml
@@ -43,6 +43,7 @@ http:
     # - `--(not-)reset-db-connections`
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
+    # - `--(not-)reset-debug-info`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -4,18 +4,18 @@ declare(strict_types = 1);
 
 namespace AvtoDev\RoadRunnerLaravel\Worker\CallbacksInitializer;
 
-use AvtoDev\RoadRunnerLaravel\Worker\Callbacks\CallbacksInterface;
-use AvtoDev\RoadRunnerLaravel\Worker\StartOptions\StartOptionsInterface;
-use AvtoDev\RoadRunnerLaravel\Worker\WorkerInterface;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Database\Connection as DatabaseConnection;
-use Illuminate\Database\DatabaseManager;
-use Illuminate\Http\Request;
-use Illuminate\Redis\Connections\Connection as RedisConnection;
-use Illuminate\Redis\RedisManager;
 use Illuminate\Support\Str;
+use Illuminate\Http\Request;
+use Illuminate\Redis\RedisManager;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Contracts\Foundation\Application;
+use AvtoDev\RoadRunnerLaravel\Worker\WorkerInterface;
+use Illuminate\Database\Connection as DatabaseConnection;
+use Illuminate\Redis\Connections\Connection as RedisConnection;
+use AvtoDev\RoadRunnerLaravel\Worker\Callbacks\CallbacksInterface;
+use AvtoDev\RoadRunnerLaravel\Worker\StartOptions\StartOptionsInterface;
 
 /**
  * @see \AvtoDev\RoadRunnerLaravel\Worker\Worker::start() - Look for callback parameters

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -123,19 +123,19 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
-     * For option "--reset-debug-info".
+     * For option "--update-app-stats".
      *
      * @param CallbacksInterface $callbacks
      * @param bool|mixed         $value
      *
      * @return void
      */
-    protected function initResetDebugInfo(CallbacksInterface $callbacks, $value)
+    protected function initUpdateAppStats(CallbacksInterface $callbacks, $value)
     {
         if ($value === true) {
             $callbacks->beforeLoopIterationStack()->push(function (Application $app) {
-                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+                $app->instance(self::ABSTRACT_REQUEST_PROCESSING_START_TIME, \microtime(true));
+                $app->instance(self::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY, \memory_get_usage());
             });
         }
     }

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -134,7 +134,7 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     {
         if ($value === true) {
             $callbacks->beforeLoopIterationStack()
-                ->push(function (Application $app, ServerRequestInterface $request) {
+                ->push(function (Application $app) {
                     $_SERVER['LARAVEL_START_TIME']   = microtime(true);
                     $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
                 });

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -123,6 +123,25 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
+     * For option "--reset-debug-info"
+     *
+     * @param CallbacksInterface $callbacks
+     * @param bool|mixed         $value
+     *
+     * @return void
+     */
+    protected function initResetDebugInfo(CallbacksInterface $callbacks, $value)
+    {
+        if ($value === true) {
+            $callbacks->beforeLoopIterationStack()
+                ->push(function (Application $app, ServerRequestInterface $request) {
+                    $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                    $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+                });
+        }
+    }
+
+    /**
      * For option: "--reset-db-connections".
      *
      * @param CallbacksInterface $callbacks

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -123,7 +123,7 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
-     * For option "--reset-debug-info"
+     * For option "--reset-debug-info".
      *
      * @param CallbacksInterface $callbacks
      * @param bool|mixed         $value
@@ -133,11 +133,10 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     protected function initResetDebugInfo(CallbacksInterface $callbacks, $value)
     {
         if ($value === true) {
-            $callbacks->beforeLoopIterationStack()
-                ->push(function (Application $app) {
-                    $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-                    $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-                });
+            $callbacks->beforeLoopIterationStack()->push(function (Application $app) {
+                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+            });
         }
     }
 

--- a/src/Worker/CallbacksInitializer/CallbacksInitializerInterface.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializerInterface.php
@@ -18,14 +18,14 @@ interface CallbacksInitializerInterface
     const FORCE_HTTPS_EXTERNAL_HEADER_NAME = 'FORCE-HTTPS';
 
     /**
-     * App binding key for storing timestamp before request processing.
+     * Incoming request object macros name for accessing to the "before request processed" timestamp.
      */
-    const ABSTRACT_REQUEST_PROCESSING_START_TIME = 'REQUEST_PROCESSING_START_TIME';
+    const REQUEST_TIMESTAMP_MACRO = 'getTimestamp';
 
     /**
-     * App binding key for storing allocated memory size before request processing.
+     * Incoming request object macros name for accessing to the "before request processed" allocated memory size.
      */
-    const ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY = 'REQUEST_PROCESSING_ALLOCATED_MEMORY';
+    const REQUEST_ALLOCATED_MEMORY_MACRO = 'getAllocatedMemory';
 
     /**
      * Constructor.

--- a/src/Worker/CallbacksInitializer/CallbacksInitializerInterface.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializerInterface.php
@@ -18,6 +18,16 @@ interface CallbacksInitializerInterface
     const FORCE_HTTPS_EXTERNAL_HEADER_NAME = 'FORCE-HTTPS';
 
     /**
+     * App binding key for storing timestamp before request processing.
+     */
+    const ABSTRACT_REQUEST_PROCESSING_START_TIME = 'REQUEST_PROCESSING_START_TIME';
+
+    /**
+     * App binding key for storing allocated memory size before request processing.
+     */
+    const ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY = 'REQUEST_PROCESSING_ALLOCATED_MEMORY';
+
+    /**
      * Constructor.
      *
      * @param StartOptionsInterface $start_options

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -93,12 +93,6 @@ class Worker implements WorkerInterface
 
         // Initialize callbacks, based on start options
         $initializer->makeInit();
-
-        // Fixed start time and memory usage
-        $this->callbacks()->beforeLoopIterationStack()->push(function () {
-            $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-            $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-        });
     }
 
     /**

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -154,6 +154,9 @@ class Worker implements WorkerInterface
 
         while ($req = $this->psr7_client->acceptRequest()) {
             try {
+                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+
                 $this->callbacks->beforeLoopIterationStack()->callEach($this->app, $req);
 
                 $request = Request::createFromBase($this->http_factory->createRequest($req));

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -93,6 +93,12 @@ class Worker implements WorkerInterface
 
         // Initialize callbacks, based on start options
         $initializer->makeInit();
+
+        // Fixed start time and memory usage
+        $this->callbacks()->beforeLoopIterationStack()->push(function () {
+            $_SERVER['LARAVEL_START_TIME']   = microtime(true);
+            $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
+        });
     }
 
     /**
@@ -154,9 +160,6 @@ class Worker implements WorkerInterface
 
         while ($req = $this->psr7_client->acceptRequest()) {
             try {
-                $_SERVER['LARAVEL_START_TIME']   = microtime(true);
-                $_SERVER['LARAVEL_START_MEMORY'] = memory_get_usage();
-
                 $this->callbacks->beforeLoopIterationStack()->callEach($this->app, $req);
 
                 $request = Request::createFromBase($this->http_factory->createRequest($req));

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -240,7 +240,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     public function testResetDebugInfoWithPassingTrue()
     {
         $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, true]);
-        $closure = $this->callbacks->afterLoopIterationStack()->first();
+        $closure = $this->callbacks->beforeLoopIterationStack()->first();
         $closure($this->app); // Test direct calling
         $this->assertInstanceOf(\Closure::class, $closure);
     }
@@ -251,7 +251,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     public function testResetDebugInfoWithPassingFalse()
     {
         $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, false]);
-        $this->assertEmpty($this->callbacks->afterLoopIterationStack());
+        $this->assertEmpty($this->callbacks->beforeLoopIterationStack());
     }
 
     /**

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -58,6 +58,15 @@ class CallbacksInitializerTest extends AbstractTestCase
     {
         $this->assertSame('init', CallbacksInitializer::RULE_METHOD_PREFIX);
         $this->assertSame('HTTPS', CallbacksInitializer::FORCE_HTTPS_HEADER_NAME);
+
+        $this->assertSame(
+            'REQUEST_PROCESSING_START_TIME',
+            CallbacksInitializer::ABSTRACT_REQUEST_PROCESSING_START_TIME
+        );
+        $this->assertSame(
+            'REQUEST_PROCESSING_ALLOCATED_MEMORY',
+            CallbacksInitializer::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY
+        );
     }
 
     /**
@@ -237,21 +246,38 @@ class CallbacksInitializerTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testResetDebugInfoWithPassingTrue()
+    public function testUpdateAppStatsWithPassingTrue()
     {
-        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, true]);
+        $this->assertFalse($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY));
+        $this->assertFalse($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_START_TIME));
+
+        $this->callMethod($this->initializer, 'initUpdateAppStats', [$this->callbacks, true]);
         $closure = $this->callbacks->beforeLoopIterationStack()->first();
         $closure($this->app); // Test direct calling
-        $this->assertInstanceOf(\Closure::class, $closure);
+
+        $this->assertTrue($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY));
+        $this->assertInternalType(
+            'integer',
+            $this->app->make($this->initializer::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY)
+        );
+
+        $this->assertTrue($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_START_TIME));
+        $this->assertInternalType(
+            'float',
+            $this->app->make($this->initializer::ABSTRACT_REQUEST_PROCESSING_START_TIME)
+        );
     }
 
     /**
      * @return void
      */
-    public function testResetDebugInfoWithPassingFalse()
+    public function testUpdateAppStatsWithPassingFalse()
     {
-        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, false]);
+        $this->callMethod($this->initializer, 'initUpdateAppStats', [$this->callbacks, false]);
         $this->assertEmpty($this->callbacks->beforeLoopIterationStack());
+
+        $this->assertFalse($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_ALLOCATED_MEMORY));
+        $this->assertFalse($this->app->bound($this->initializer::ABSTRACT_REQUEST_PROCESSING_START_TIME));
     }
 
     /**

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -237,6 +237,26 @@ class CallbacksInitializerTest extends AbstractTestCase
     /**
      * @return void
      */
+    public function testResetDebugInfoWithPassingTrue()
+    {
+        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, true]);
+        $closure = $this->callbacks->afterLoopIterationStack()->first();
+        $closure($this->app); // Test direct calling
+        $this->assertInstanceOf(\Closure::class, $closure);
+    }
+
+    /**
+     * @return void
+     */
+    public function testResetDebugInfoWithPassingFalse()
+    {
+        $this->callMethod($this->initializer, 'initResetDebugInfo', [$this->callbacks, false]);
+        $this->assertEmpty($this->callbacks->afterLoopIterationStack());
+    }
+
+    /**
+     * @return void
+     */
     public function testResetRedisConnectionsWithPassingTrue()
     {
         $this->callMethod($this->initializer, 'initResetRedisConnections', [$this->callbacks, true]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

### Added

- Worker option `--(not-)inject-stats-into-request` for injecting macroses into request object for accessing timestamp and allocated memory size (before request processing) values

Original PR: #8 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code
- [ ] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v1.x.x`, if it does not exists
> * Add description under `Added` / `Changed` / `Fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document
