### PR TITLE
Mock is_uploaded_file function for Symfony\Component\HttpFoundation\File namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.3.0
+
+### Added
+
+- Worker option `--(not-)mock-is-uploaded-file`. Function `is-uploaded-file` for `Symfony\Component\HttpFoundation\File` will always return true.
+
 ## v1.2.1
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you wants to disable package service-provider auto discover, just add into yo
 `--(not-)reset-redis-connections` | Обрывает (или нет) соединения с redis после обработки входящего запроса
 `--(not-)refresh-app` | Принудительно пересоздает инстанс приложения после обработки **каждого** запроса
 `--(not-)inject-stats-into-request` | **Перед** обработкой **каждого** запроса добавляет в объект `Request` макросы (`::getTimestamp()` и `::getAllocatedMemory()`), возвращающие значения временной метки и объем выделенной памяти
+`--(not-)mock-is-uploaded-file` | Перекрывает метод `is_uploaded-file` для `Symfony\Component\HttpFoundation\File`
 
 > Параметры запуска указываются в файле-конфигурации (например: `./.rr.local.yml`) по пути `http.workers.command`, например: `php ./vendor/bin/rr-worker --some-parameter`
 

--- a/configs/rr/.rr.local.yml
+++ b/configs/rr/.rr.local.yml
@@ -48,6 +48,7 @@ http:
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
     # - `--(not-)inject-stats-into-request`
+    # - `--(not-)mock-is-uploaded-file`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/configs/rr/.rr.yml
+++ b/configs/rr/.rr.yml
@@ -48,6 +48,7 @@ http:
     # - `--(not-)reset-redis-connections`
     # - `--(not-)refresh-app`
     # - `--(not-)inject-stats-into-request`
+    # - `--(not-)mock-is-uploaded-file`
     command: "php ./vendor/bin/rr-worker"
 
     # connection method (pipes, tcp://:9000, unix://socket.unix). default "pipes"

--- a/hacks/is_uploaded_file.php
+++ b/hacks/is_uploaded_file.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\File {
+
+    function is_uploaded_file($name)
+    {
+        return true;
+    }
+}

--- a/src/Worker/CallbacksInitializer/CallbacksInitializer.php
+++ b/src/Worker/CallbacksInitializer/CallbacksInitializer.php
@@ -149,6 +149,23 @@ class CallbacksInitializer implements CallbacksInitializerInterface
     }
 
     /**
+     * For option "--mock-is-uploaded-file".
+     *
+     * @param CallbacksInterface $callbacks
+     * @param bool|mixed         $value
+     *
+     * @return void
+     */
+    protected function initMockIsUploadedFile(CallbacksInterface $callbacks, $value)
+    {
+        if ($value === true) {
+            $callbacks->beforeLoopStarts()->push(function (Application $app) {
+                require __DIR__ . '/../../../hacks/is_uploaded_file.php';
+            });
+        }
+    }
+
+    /**
      * For option: "--reset-db-connections".
      *
      * @param CallbacksInterface $callbacks

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -77,8 +77,7 @@ class CallbacksInitializerTest extends AbstractTestCase
      */
     public function testAutoInitMethodsCalling()
     {
-        $mock = new class(new StartOptions(['--bla-bla']), $this->callbacks) extends CallbacksInitializer
-        {
+        $mock                  = new class(new StartOptions(['--bla-bla']), $this->callbacks) extends CallbacksInitializer {
             public $called     = false;
 
             public $should_not = false;

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -77,7 +77,8 @@ class CallbacksInitializerTest extends AbstractTestCase
      */
     public function testAutoInitMethodsCalling()
     {
-        $mock                  = new class(new StartOptions(['--bla-bla']), $this->callbacks) extends CallbacksInitializer {
+        $mock = new class(new StartOptions(['--bla-bla']), $this->callbacks) extends CallbacksInitializer
+        {
             public $called     = false;
 
             public $should_not = false;
@@ -292,5 +293,28 @@ class CallbacksInitializerTest extends AbstractTestCase
     {
         $this->callMethod($this->initializer, 'initResetRedisConnections', [$this->callbacks, false]);
         $this->assertEmpty($this->callbacks->afterLoopIterationStack());
+    }
+
+    /**
+     * @throws \LogicException
+     * @throws \ReflectionException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     *
+     * @return void
+     */
+    public function testInitMockIsUploadedFile()
+    {
+        $sym_function_name = '\Symfony\Component\HttpFoundation\File\is_uploaded_file';
+
+        $this->assertFalse(function_exists($sym_function_name));
+
+        $this->callMethod($this->initializer, 'initMockIsUploadedFile', [$this->callbacks, true]);
+        $closure = $this->callbacks->beforeLoopStarts()->first();
+        $closure($this->app);
+
+        $this->assertTrue(function_exists($sym_function_name));
+
+        $this->assertTrue(\Symfony\Component\HttpFoundation\File\is_uploaded_file('some name'));
+        $this->assertFalse(\is_uploaded_file('some name'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes

## Description

When you try to validate uploaded file by Laravel you will always get validation error becouse Symfony use `is_uploaded_file` function to validate file.

Now we can mock this function just for `Symfony\Component\HttpFoundation\File`. It will always return `true`

Fixes #10 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file
