### PR TITLE
Laravel 5.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ after_success:
 
 matrix:
   include:
-  - php: 7.0
-  - php: 7.0
-    env: setup=lowest
 
   - php: 7.1
   - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ after_success:
 matrix:
   include:
 
-  - php: 7.1
-  - php: 7.1
+  - php: 7.1.3
+  - php: 7.1.3
     env: setup=lowest
 
   - php: 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.0.0
+
+### Added
+
+- Laravel **v5.8** supports
+
+### Changed
+
+- Minimal `php` version now is `7.1.3`
+- Minimal `illuminate/*` and `laravel/*` package versions now is `>=5.8`
+
 ## v1.4.0
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "homepage": "https://github.com/avto-dev"
     }],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "ext-mbstring": "*",
-        "illuminate/contracts": ">=5.5.0",
-        "illuminate/support": ">=5.5.0",
-        "illuminate/http": ">=5.5.0",
-        "illuminate/routing": ">=5.5.0",
+        "illuminate/contracts": ">=5.8.0 <5.9.0",
+        "illuminate/support": ">=5.8.0 <5.9.0",
+        "illuminate/http": ">=5.8.0 <5.9.0",
+        "illuminate/routing": ">=5.8.0 <5.9.0",
         "spiral/roadrunner": "^1.4",
         "symfony/psr-http-message-bridge": "^1.1"
     },
@@ -28,7 +28,7 @@
         "ext-sqlite3": "*",
         "avto-dev/dev-tools": "^1.9",
         "jeremeamia/superclosure": "^2.4",
-        "laravel/laravel": ">=5.5.0",
+        "laravel/laravel": ">=5.8.0 <5.9.0",
         "mockery/mockery": "0.9.* || ~1.0",
         "phpstan/phpstan": "~0.9 || ^0.10",
         "phpunit/phpunit": "^6.4 || ~7.0",

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,17 @@
     ],
     "type": "library",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "avto-dev",
-            "homepage": "https://github.com/avto-dev"
-        }
-    ],
+    "authors": [{
+        "name": "avto-dev",
+        "homepage": "https://github.com/avto-dev"
+    }],
     "require": {
         "php": ">=7.0",
         "ext-mbstring": "*",
-        "illuminate/contracts": ">=5.5.0 <5.8.0",
-        "illuminate/support": ">=5.5.0 <5.8.0",
-        "illuminate/http": ">=5.5.0 <5.8.0",
-        "illuminate/routing": ">=5.5.0 <5.8.0",
+        "illuminate/contracts": ">=5.5.0",
+        "illuminate/support": ">=5.5.0",
+        "illuminate/http": ">=5.5.0",
+        "illuminate/routing": ">=5.5.0",
         "spiral/roadrunner": "^1.4",
         "symfony/psr-http-message-bridge": "^1.1"
     },
@@ -30,7 +28,7 @@
         "ext-sqlite3": "*",
         "avto-dev/dev-tools": "^1.9",
         "jeremeamia/superclosure": "^2.4",
-        "laravel/laravel": ">=5.5.0 <5.8.0",
+        "laravel/laravel": ">=5.5.0",
         "mockery/mockery": "0.9.* || ~1.0",
         "phpstan/phpstan": "~0.9 || ^0.10",
         "phpunit/phpunit": "^6.4 || ~7.0",

--- a/tests/Middleware/ForceHttpsMiddlewareTest.php
+++ b/tests/Middleware/ForceHttpsMiddlewareTest.php
@@ -29,7 +29,7 @@ class ForceHttpsMiddlewareTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Support/Stacks/BasicStackTest.php
+++ b/tests/Support/Stacks/BasicStackTest.php
@@ -19,7 +19,7 @@ class BasicStackTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Worker/Callbacks/CallbacksTest.php
+++ b/tests/Worker/Callbacks/CallbacksTest.php
@@ -20,7 +20,7 @@ class CallbacksTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
+++ b/tests/Worker/CallbacksInitializer/CallbacksInitializerTest.php
@@ -35,7 +35,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -46,7 +46,7 @@ class CallbacksInitializerTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($_ENV['APP_FORCE_HTTPS']);
 

--- a/tests/Worker/StartOptions/StartOptionsTest.php
+++ b/tests/Worker/StartOptions/StartOptionsTest.php
@@ -23,7 +23,7 @@ class StartOptionsTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Worker/WorkerTest.php
+++ b/tests/Worker/WorkerTest.php
@@ -23,7 +23,7 @@ class WorkerTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($_ENV['APP_BOOTSTRAP_PATH'], $_ENV['APP_BASE_PATH']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes

### Added

- Laravel **v5.8** supports

### Changed

- Minimal `php` version now is `7.1.3`
- Minimal `illuminate/*` and `laravel/*` package versions now is `>=5.8`

Fixes #13

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file
