### PR TITLE
Adds the ability to reset the application after a request is handled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.3.0
+
+### Added
+
+- Ability to reset the application state after handling a request.
+
 ## Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Name | Description
 `--(not-)force-https` | Force (or not) `https` schema usage (eg. for links generation)
 `--(not-)reset-db-connections` | Drop (or not) database connections after incoming request serving
 `--(not-)reset-redis-connections` | Drop (or not) Redis connections after incoming request serving
+`--(not-)reset-application` | Reset (or not) application state after incoming request serving
 `--(not-)refresh-app` | Force refresh application instance after incoming request serving
 `--(not-)inject-stats-into-request` | Inject into each `Request` object macros `::getTimestamp()` and `::getAllocatedMemory()` that returns timestamp and used allocated memory size
 `--not-fix-symfony-file-validation` | Do **not** fix `isValid` method in `\Symfony\Component\HttpFoundation\File\UploadedFile` [#10]

--- a/src/Resetter/ClearCookies.php
+++ b/src/Resetter/ClearCookies.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Resetter;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Cookie\CookieJar;
+
+class ClearCookies implements ResetterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function reset(Container $app): void
+    {
+        if ($app->has('cookie')) {
+            /** @var CookieJar $cookies */
+            $cookies = $app->make('cookie');
+
+            foreach ($cookies->getQueuedCookies() as $value) {
+                $cookies->unqueue($value->getName());
+            }
+        }
+    }
+}

--- a/src/Resetter/ClearCookies.php
+++ b/src/Resetter/ClearCookies.php
@@ -2,7 +2,7 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Resetter;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 use Illuminate\Cookie\CookieJar;
 
 class ClearCookies implements ResetterInterface

--- a/src/Resetter/ResetAuth.php
+++ b/src/Resetter/ResetAuth.php
@@ -2,7 +2,7 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Resetter;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Facade;
 use ReflectionObject;
 

--- a/src/Resetter/ResetAuth.php
+++ b/src/Resetter/ResetAuth.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Resetter;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use ReflectionObject;
+
+class ResetAuth implements ResetterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function reset(Container $app): void
+    {
+        if ($app->has('auth')) {
+            $auth = $app->make('auth');
+            $reference = new ReflectionObject($auth);
+
+            if ($reference->hasProperty('guards')) {
+                $guards = $reference->getProperty('guards');
+            } else {
+                $guards = $reference->getProperty('drivers');
+            }
+
+            $guards->setAccessible(true);
+            $guards->setValue($auth, []);
+
+            $app->forgetInstance('auth.driver');
+            Facade::clearResolvedInstance('auth.driver');
+        }
+    }
+}

--- a/src/Resetter/ResetRequest.php
+++ b/src/Resetter/ResetRequest.php
@@ -2,7 +2,7 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Resetter;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Facade;
 
 class ResetRequest implements ResetterInterface

--- a/src/Resetter/ResetRequest.php
+++ b/src/Resetter/ResetRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Resetter;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Facade;
+
+class ResetRequest implements ResetterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function reset(Container $app): void
+    {
+        $app->forgetInstance('request');
+        Facade::clearResolvedInstance('request');
+    }
+}

--- a/src/Resetter/ResetSession.php
+++ b/src/Resetter/ResetSession.php
@@ -2,7 +2,7 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Resetter;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\Facades\Facade;
 use ReflectionObject;

--- a/src/Resetter/ResetSession.php
+++ b/src/Resetter/ResetSession.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Resetter;
+
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Routing\Redirector;
+use Illuminate\Support\Facades\Facade;
+use ReflectionObject;
+
+class ResetSession implements ResetterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function reset(Container $app): void
+    {
+        if ($app->has('session')) {
+            $session = $app->make('session');
+            $reference = new ReflectionObject($session);
+
+            $drivers = $reference->getProperty('drivers');
+            $drivers->setAccessible(true);
+            $drivers->setValue($session, []);
+
+            $app->forgetInstance('session.store');
+            Facade::clearResolvedInstance('session.store');
+
+            if ($app->has('redirect')) {
+                /** @var Redirector $redirect */
+                $redirect = $app->make('redirect');
+                $redirect->setSession($app->make('session.store'));
+            }
+        }
+    }
+}

--- a/src/Resetter/ResetterInterface.php
+++ b/src/Resetter/ResetterInterface.php
@@ -2,7 +2,7 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Resetter;
 
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Container\Container;
 
 interface ResetterInterface
 {

--- a/src/Resetter/ResetterInterface.php
+++ b/src/Resetter/ResetterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Resetter;
+
+use Illuminate\Contracts\Container\Container;
+
+interface ResetterInterface
+{
+    /**
+     * Handles resetting of the application.
+     *
+     * @param Container $app
+     */
+    public function reset(Container $app): void;
+}

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -2,6 +2,11 @@
 
 namespace AvtoDev\RoadRunnerLaravel\Worker;
 
+use AvtoDev\RoadRunnerLaravel\Resetter\ResetAuth;
+use AvtoDev\RoadRunnerLaravel\Resetter\ClearCookies;
+use AvtoDev\RoadRunnerLaravel\Resetter\ResetRequest;
+use AvtoDev\RoadRunnerLaravel\Resetter\ResetSession;
+
 interface WorkerInterface
 {
     /**
@@ -18,6 +23,13 @@ interface WorkerInterface
      * Environment value name for forcing "https" schema.
      */
     public const ENV_NAME_APP_FORCE_HTTPS = 'APP_FORCE_HTTPS';
+
+    public const APPLICATION_RESETTERS = [
+        ClearCookies::class,
+        ResetAuth::class,
+        ResetRequest::class,
+        ResetSession::class,
+    ];
 
     /**
      * Start worker events loop.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

This PR resets the state of the application after a request is handled by a worker by enabling the `--reset-application` switch which will remove instances related to auth, request and session and unqueue any dangling cookies from the application.

Fixes #22 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file