### PR TITLE
Add laravel 7.x supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,12 @@ jobs:
       env: laravel=5.8
     - php: 7.3
       env: coverage=true laravel=6.*
+    - php: 7.3
+      env: coverage=true laravel=7.*
 
     - php: 7.4
       env: setup=lowest
     - php: 7.4
       env: coverage=true laravel=6.*
+    - php: 7.4
+      env: coverage=true laravel=7.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## v3.1.0
 
-### Added
+### Changed
 
 - Maximal `illuminate/*` packages version now is `7.*`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.1.0
+
+### Added
+
+- Maximal `illuminate/*` packages version now is `7.*`
+
+### Removed
+
+- Unused dev-dependency `jeremeamia/superclosure`
+
 ## v3.0.2
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:1.8.6 AS composer
 
-FROM php:7.1.3-alpine
+FROM php:7.2.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ static:
 
 Roadrunner server starting:
 
-```bash
+```shell script
 $ rr -c ./.rr.yaml serve -d
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": "^7.1.3",
         "ext-mbstring": "*",
-        "illuminate/contracts": "^5.5 || ~6.0",
-        "illuminate/support": "^5.5 || ~6.0",
-        "illuminate/http": "^5.5 || ~6.0",
-        "illuminate/routing": "^5.5 || ~6.0",
-        "spiral/roadrunner": "~1.5",
+        "illuminate/contracts": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/support": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/http": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/routing": "^5.5 || ~6.0 || ~7.0",
+        "spiral/roadrunner": "~1.6",
         "symfony/psr-http-message-bridge": "^1.2",
         "zendframework/zend-diactoros": "^2"
     },
@@ -27,11 +27,10 @@
         "ext-pdo": "*",
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
-        "jeremeamia/superclosure": "^2.4",
-        "laravel/laravel": "^5.5 || ~6.0",
+        "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "~0.12",
-        "phpunit/phpunit": "^6.4 || ~7.5"
+        "phpunit/phpunit": "^6.4 || ~7.5 || ~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "~0.12",
-        "phpunit/phpunit": "^6.4 || ~7.5 || ~8.0"
+        "phpunit/phpunit": "^6.4 || ~7.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No

## Description

### Added

- Maximal `illuminate/*` packages version now is `7.*`

### Removed

- Unused dev-dependency `jeremeamia/superclosure`

Fixes #34 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
