### PR TITLE
Update RoadRunner package up to 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.2.0
+
+### Changed
+
+- Dependency `zendframework/zend-diactoros` replaced with `laminas/laminas-diactoros`
+- Worker PSR7 fabric method uses `Laminas\Diactoros\ResponseFactory` as ResponseFactory (instead `Zend\Diactoros\ResponseFactory`)
+- Minimal required version of `spiral/roadrunner` package changed from `~1.6` to `~1.7`
+
 ## v3.1.0
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dc_bin := $(shell command -v docker-compose 2> /dev/null)
 SHELL = /bin/sh
 RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
 
-.PHONY : help build latest install lowest test test-cover 'shell' clean
+.PHONY : help build latest install lowest test test-cover clean
 .DEFAULT_GOAL : help
 
 # This will output the help for each task. thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -34,8 +34,7 @@ test-cover: ## Execute php tests with coverage
 	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
-    $(RUN_APP_ARGS) sh
+	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" $(RUN_APP_ARGS) sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "illuminate/support": "^5.5 || ~6.0 || ~7.0",
         "illuminate/http": "^5.5 || ~6.0 || ~7.0",
         "illuminate/routing": "^5.5 || ~6.0 || ~7.0",
-        "spiral/roadrunner": "~1.6",
+        "spiral/roadrunner": "~1.7",
         "symfony/psr-http-message-bridge": "^1.2",
-        "zendframework/zend-diactoros": "^2"
+        "laminas/laminas-diactoros": "^2"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -257,7 +257,7 @@ class Worker implements WorkerInterface
             new \Spiral\RoadRunner\Diactoros\ServerRequestFactory,
             new \Spiral\RoadRunner\Diactoros\StreamFactory,
             new \Spiral\RoadRunner\Diactoros\UploadedFileFactory,
-            new \Zend\Diactoros\ResponseFactory
+            new \Laminas\Diactoros\ResponseFactory
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No

## Description

### Changed

- Dependency `zendframework/zend-diactoros` replaced with `laminas/laminas-diactoros`
- Worker PSR7 fabric method uses `Laminas\Diactoros\ResponseFactory` as ResponseFactory (instead `Zend\Diactoros\ResponseFactory`)
- Minimal required version of `spiral/roadrunner` package changed from `~1.6` to `~1.7`

Refers: https://github.com/spiral/roadrunner/releases/tag/v1.7.1

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
