### PR TITLE
Upgrade to use 2.0 of symfony/psr-http-message-bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## 3.2.1
+
+### Changed
+
+- Upgraded to use symfony/psr-http-message-bridge ^2.0
+
 ## v3.2.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Upgraded to use symfony/psr-http-message-bridge ^2.0
+- Updated symfony/psr-http-message-bridge to allow ^2.0
 
 ## v3.2.0
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/http": "^5.5 || ~6.0 || ~7.0",
         "illuminate/routing": "^5.5 || ~6.0 || ~7.0",
         "spiral/roadrunner": "~1.7",
-        "symfony/psr-http-message-bridge": "^2.0",
+        "symfony/psr-http-message-bridge": "^1.2 || ^2.0",
         "laminas/laminas-diactoros": "^2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/http": "^5.5 || ~6.0 || ~7.0",
         "illuminate/routing": "^5.5 || ~6.0 || ~7.0",
         "spiral/roadrunner": "~1.7",
-        "symfony/psr-http-message-bridge": "^1.2",
+        "symfony/psr-http-message-bridge": "^2.0",
         "laminas/laminas-diactoros": "^2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

Laravel Passport, as of versions greater than 8.4, have now upgraded to use symfony/psr-http-message-bridge ^2.0. This now presents a conflict, and whether to decide to lock the Laravel Passport version or roadrunner-laravel. I have bumped the version from ^1.2 to ^2.0 and ran current PHPUnit tests, 63 has passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

I have updated the CHANGELOG.md to version 3.2.1 to state the upgrade to symfony/psr-http-message-bridge ^2.0
