### PR TITLE
App state resseting error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Default package configuration includes `LoopErrorOccurredEvent` event listeners: `SendExceptionToStderrListener` and `StopWorkerListener`
-- When "debug mode" (`app.debug`) is **not** enabled - client will get only `Internal server error` string instead exception with stacktrace
+- Default package configuration includes `LoopErrorOccurredEvent` event listeners: `SendExceptionToStderrListener` and `StopWorkerListener` [#42]
+- When "debug mode" (`app.debug`) is **not** enabled - client will get only `Internal server error` string instead exception with stacktrace [#42]
 
 ### Fixed
 
 - Double response sending on request processing error (calling `$psr7_client->respond` and `$psr7_client->getWorker()->error` after that)
+
+[#42]:https://github.com/avto-dev/roadrunner-laravel/issues/42
 
 ## v3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Default package configuration includes `LoopErrorOccurredEvent` event listeners: `SendExceptionToStderrListener` and `StopWorkerListener`
-- When "debug mode" (`app.debug`) is not enabled - client will get only `Internal server error` string instead exception with stacktrace
+- When "debug mode" (`app.debug`) is **not** enabled - client will get only `Internal server error` string instead exception with stacktrace
 
 ### Fixed
 
-- Double response sending on request processing error (using `$psr7_client->respond` and `$psr7_client->getWorker()->error` after that)
+- Double response sending on request processing error (calling `$psr7_client->respond` and `$psr7_client->getWorker()->error` after that)
 
 ## v3.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.3.0
+
+### Added
+
+- Event `LoopErrorOccurredEvent` (triggered on request processing exception)
+- Listener `SendExceptionToStderrListener` for direct exception sending (as a string) into `stderr`
+- Listener `StopWorkerListener` for worker stopping
+
+### Changed
+
+- Default package configuration includes `LoopErrorOccurredEvent` event listeners: `SendExceptionToStderrListener` and `StopWorkerListener`
+- When "debug mode" (`app.debug`) is not enabled - client will get only `Internal server error` string instead exception with stacktrace
+
+### Fixed
+
+- Double response sending on request processing error (using `$psr7_client->respond` and `$psr7_client->getWorker()->error` after that)
+
 ## v3.2.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Event classname              | Application object | HTTP server request | HTTP r
 `AfterRequestHandlingEvent`  |          ✔         |                     |       ✔      |       ✔
 `AfterLoopIterationEvent`    |          ✔         |                     |       ✔      |       ✔
 `AfterLoopStoppedEvent`      |          ✔         |                     |              |
+`LoopErrorOccurredEvent`     |          ✔         |          ✔          |              |
 
 Simple `.rr.yaml` config example:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easy way for connecting [RoadRunner][roadrunner] and [Laravel][laravel] applicat
 Require this package with composer using next command:
 
 ```shell script
-$ composer require avto-dev/roadrunner-laravel "^3.0"
+$ composer require avto-dev/roadrunner-laravel "^3.3"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]).

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ After that you can modify configuration files as you wish.
 
 After package installation you can use provided "binary" file as RoadRunner worker: `./vendor/bin/rr-worker`. This worker allows you to interact with incoming requests and outcoming responses using [laravel events system][laravel_events]. Also events contains:
 
-Event classname              | Application object | HTTP server request | HTTP request | HTTP response 
----------------------------- | :----------------: | :-----------------: | :----------: | :-----------:
-`BeforeLoopStartedEvent`     |          ✔         |                     |              |
-`BeforeLoopIterationEvent`   |          ✔         |          ✔          |              |
-`BeforeRequestHandlingEvent` |          ✔         |                     |       ✔      |
-`AfterRequestHandlingEvent`  |          ✔         |                     |       ✔      |       ✔
-`AfterLoopIterationEvent`    |          ✔         |                     |       ✔      |       ✔
-`AfterLoopStoppedEvent`      |          ✔         |                     |              |
-`LoopErrorOccurredEvent`     |          ✔         |          ✔          |              |
+Event classname              | Application object | HTTP server request | HTTP request | HTTP response | Exception
+---------------------------- | :----------------: | :-----------------: | :----------: | :-----------: | :-------:
+`BeforeLoopStartedEvent`     |          ✔         |                     |              |               |
+`BeforeLoopIterationEvent`   |          ✔         |          ✔          |              |               |
+`BeforeRequestHandlingEvent` |          ✔         |                     |       ✔      |               |
+`AfterRequestHandlingEvent`  |          ✔         |                     |       ✔      |       ✔       |
+`AfterLoopIterationEvent`    |          ✔         |                     |       ✔      |       ✔       |
+`AfterLoopStoppedEvent`      |          ✔         |                     |              |               |
+`LoopErrorOccurredEvent`     |          ✔         |          ✔          |              |               |     ✔
 
 Simple `.rr.yaml` config example:
 

--- a/config/roadrunner.php
+++ b/config/roadrunner.php
@@ -93,6 +93,11 @@ return [
         Events\AfterLoopStoppedEvent::class => [
             //
         ],
+
+        Events\LoopErrorOccurred::class => [
+            Listeners\SendExceptionToStderrListener::class,
+            Listeners\StopWorkerListener::class,
+        ],
     ],
 
     /*

--- a/config/roadrunner.php
+++ b/config/roadrunner.php
@@ -94,7 +94,7 @@ return [
             //
         ],
 
-        Events\LoopErrorOccurred::class => [
+        Events\LoopErrorOccurredEvent::class => [
             Listeners\SendExceptionToStderrListener::class,
             Listeners\StopWorkerListener::class,
         ],

--- a/src/Events/Contracts/WithException.php
+++ b/src/Events/Contracts/WithException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AvtoDev\RoadRunnerLaravel\Events\Contracts;
+
+use Throwable;
+
+interface WithException
+{
+    /**
+     * Get exception instance.
+     *
+     * @return Throwable
+     */
+    public function exception(): Throwable;
+}

--- a/src/Events/LoopErrorOccurred.php
+++ b/src/Events/LoopErrorOccurred.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Events;
+
+use Throwable;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithException;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+
+final class LoopErrorOccurred implements WithApplication, WithException
+{
+    /**
+     * @var ApplicationContract
+     */
+    private $app;
+
+    /**
+     * @var Throwable
+     */
+    private $exception;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param ApplicationContract $app
+     * @param Throwable           $exception
+     */
+    public function __construct(ApplicationContract $app, Throwable $exception)
+    {
+        $this->app       = $app;
+        $this->exception = $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function application(): ApplicationContract
+    {
+        return $this->app;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function exception(): Throwable
+    {
+        return $this->exception;
+    }
+}

--- a/src/Events/LoopErrorOccurred.php
+++ b/src/Events/LoopErrorOccurred.php
@@ -6,7 +6,6 @@ namespace AvtoDev\RoadRunnerLaravel\Events;
 
 use Throwable;
 use Psr\Http\Message\ServerRequestInterface;
-use AvtoDev\RoadRunnerLaravel\Events\Contracts;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 final class LoopErrorOccurred implements Contracts\WithApplication, Contracts\WithException, Contracts\WithServerRequest

--- a/src/Events/LoopErrorOccurred.php
+++ b/src/Events/LoopErrorOccurred.php
@@ -5,11 +5,11 @@ declare(strict_types = 1);
 namespace AvtoDev\RoadRunnerLaravel\Events;
 
 use Throwable;
-use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithException;
-use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
+use Psr\Http\Message\ServerRequestInterface;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
-final class LoopErrorOccurred implements WithApplication, WithException
+final class LoopErrorOccurred implements Contracts\WithApplication, Contracts\WithException, Contracts\WithServerRequest
 {
     /**
      * @var ApplicationContract
@@ -22,15 +22,22 @@ final class LoopErrorOccurred implements WithApplication, WithException
     private $exception;
 
     /**
+     * @var ServerRequestInterface
+     */
+    private $server_request;
+
+    /**
      * Create a new event instance.
      *
-     * @param ApplicationContract $app
-     * @param Throwable           $exception
+     * @param ApplicationContract    $app
+     * @param ServerRequestInterface $server_request
+     * @param Throwable              $exception
      */
-    public function __construct(ApplicationContract $app, Throwable $exception)
+    public function __construct(ApplicationContract $app, ServerRequestInterface $server_request, Throwable $exception)
     {
-        $this->app       = $app;
-        $this->exception = $exception;
+        $this->app            = $app;
+        $this->server_request = $server_request;
+        $this->exception      = $exception;
     }
 
     /**
@@ -47,5 +54,13 @@ final class LoopErrorOccurred implements WithApplication, WithException
     public function exception(): Throwable
     {
         return $this->exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serverRequest(): ServerRequestInterface
+    {
+        return $this->server_request;
     }
 }

--- a/src/Events/LoopErrorOccurredEvent.php
+++ b/src/Events/LoopErrorOccurredEvent.php
@@ -8,7 +8,7 @@ use Throwable;
 use Psr\Http\Message\ServerRequestInterface;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
-final class LoopErrorOccurred implements Contracts\WithApplication, Contracts\WithException, Contracts\WithServerRequest
+final class LoopErrorOccurredEvent implements Contracts\WithApplication, Contracts\WithException, Contracts\WithServerRequest
 {
     /**
      * @var ApplicationContract

--- a/src/Listeners/SendExceptionToStderrListener.php
+++ b/src/Listeners/SendExceptionToStderrListener.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Listeners;
+
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithException;
+
+class SendExceptionToStderrListener implements ListenerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($event): void
+    {
+        if ($event instanceof WithException) {
+            \fwrite(\STDERR, (string) $event->exception());
+        }
+    }
+}

--- a/src/Listeners/StopWorkerListener.php
+++ b/src/Listeners/StopWorkerListener.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Listeners;
+
+use Spiral\RoadRunner\PSR7Client;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
+
+/**
+ * Common usage - stop worker on unhandled error occurring.
+ *
+ * @link https://roadrunner.dev/docs/php-restarting
+ */
+class StopWorkerListener implements ListenerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($event): void
+    {
+        if ($event instanceof WithApplication) {
+            /** @var PSR7Client $psr7_client */
+            $psr7_client = $event->application()->make(PSR7Client::class);
+
+            $psr7_client->getWorker()->stop();
+        }
+    }
+}

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -150,9 +150,9 @@ class Worker implements WorkerInterface
      *
      * @param string $base_path
      *
-     * @return ApplicationContract
      * @throws InvalidArgumentException
      *
+     * @return ApplicationContract
      */
     protected function createApplication(string $base_path): ApplicationContract
     {
@@ -171,9 +171,9 @@ class Worker implements WorkerInterface
      * @param ApplicationContract $app
      * @param PSR7Client          $psr7_client
      *
-     * @return void
      * @throws RuntimeException
      *
+     * @return void
      */
     protected function bootstrapApplication(ApplicationContract $app, PSR7Client $psr7_client): void
     {

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace AvtoDev\RoadRunnerLaravel;
 
+use Throwable;
 use RuntimeException;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
@@ -58,6 +59,8 @@ class Worker implements WorkerInterface
         $this->fireEvent($app, new Events\BeforeLoopStartedEvent($app));
 
         while ($req = $psr7_client->acceptRequest()) {
+            $responded = false;
+
             if ($refresh_app === true) {
                 $sandbox = $this->createApplication($this->base_path);
                 $this->bootstrapApplication($sandbox, $psr7_client);
@@ -80,11 +83,19 @@ class Worker implements WorkerInterface
 
                 $psr7_response = $psr7_factory->createResponse($response);
                 $psr7_client->respond($psr7_response);
+                $responded = true;
                 $http_kernel->terminate($request, $response);
 
                 $this->fireEvent($sandbox, new Events\AfterLoopIterationEvent($sandbox, $request, $response));
-            } catch (\Throwable $e) {
-                $psr7_client->getWorker()->error((string) $e);
+            } catch (Throwable $e) {
+                if ($responded !== true) {
+                    /** @var ConfigRepository $config */
+                    $config = $sandbox->make(ConfigRepository::class);
+
+                    $psr7_client->getWorker()->error($this->exceptionToString($e, $this->isDebugModeEnabled($config)));
+                }
+
+                $this->fireEvent($sandbox, new Events\LoopErrorOccurred($sandbox, $e));
             } finally {
                 unset($http_kernel, $response, $request, $sandbox);
 
@@ -93,6 +104,29 @@ class Worker implements WorkerInterface
         }
 
         $this->fireEvent($app, new Events\AfterLoopStoppedEvent($app));
+    }
+
+    /**
+     * @param Throwable $e
+     * @param bool      $is_debug
+     *
+     * @return string
+     */
+    protected function exceptionToString(Throwable $e, bool $is_debug): string
+    {
+        return $is_debug
+            ? (string) $e
+            : 'Internal server error';
+    }
+
+    /**
+     * @param ConfigRepository $config
+     *
+     * @return bool
+     */
+    protected function isDebugModeEnabled(ConfigRepository $config): bool
+    {
+        return $config->get('app.debug', false) === true;
     }
 
     /**

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -95,7 +95,7 @@ class Worker implements WorkerInterface
                     $psr7_client->getWorker()->error($this->exceptionToString($e, $this->isDebugModeEnabled($config)));
                 }
 
-                $this->fireEvent($sandbox, new Events\LoopErrorOccurred($sandbox, $req, $e));
+                $this->fireEvent($sandbox, new Events\LoopErrorOccurredEvent($sandbox, $req, $e));
             } finally {
                 unset($http_kernel, $response, $request, $sandbox);
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -72,6 +72,8 @@ class Worker implements WorkerInterface
 
             /** @var HttpKernelContract $http_kernel */
             $http_kernel = $sandbox->make(HttpKernelContract::class);
+            /** @var ConfigRepository $config */
+            $config = $sandbox->make(ConfigRepository::class);
 
             try {
                 $this->fireEvent($sandbox, new Events\BeforeLoopIterationEvent($sandbox, $req));
@@ -89,9 +91,6 @@ class Worker implements WorkerInterface
                 $this->fireEvent($sandbox, new Events\AfterLoopIterationEvent($sandbox, $request, $response));
             } catch (Throwable $e) {
                 if ($responded !== true) {
-                    /** @var ConfigRepository $config */
-                    $config = $sandbox->make(ConfigRepository::class);
-
                     $psr7_client->getWorker()->error($this->exceptionToString($e, $this->isDebugModeEnabled($config)));
                 }
 

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -95,7 +95,7 @@ class Worker implements WorkerInterface
                     $psr7_client->getWorker()->error($this->exceptionToString($e, $this->isDebugModeEnabled($config)));
                 }
 
-                $this->fireEvent($sandbox, new Events\LoopErrorOccurred($sandbox, $e));
+                $this->fireEvent($sandbox, new Events\LoopErrorOccurred($sandbox, $req, $e));
             } finally {
                 unset($http_kernel, $response, $request, $sandbox);
 
@@ -150,9 +150,9 @@ class Worker implements WorkerInterface
      *
      * @param string $base_path
      *
+     * @return ApplicationContract
      * @throws InvalidArgumentException
      *
-     * @return ApplicationContract
      */
     protected function createApplication(string $base_path): ApplicationContract
     {
@@ -171,9 +171,9 @@ class Worker implements WorkerInterface
      * @param ApplicationContract $app
      * @param PSR7Client          $psr7_client
      *
+     * @return void
      * @throws RuntimeException
      *
-     * @return void
      */
     protected function bootstrapApplication(ApplicationContract $app, PSR7Client $psr7_client): void
     {

--- a/tests/Events/LoopErrorOccurredTest.php
+++ b/tests/Events/LoopErrorOccurredTest.php
@@ -5,13 +5,13 @@ declare(strict_types = 1);
 namespace AvtoDev\RoadRunnerLaravel\Tests\Events;
 
 use Zend\Diactoros\ServerRequest;
-use AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurred;
+use AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurredEvent;
 use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithException;
 use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
 use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithServerRequest;
 
 /**
- * @covers \AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurred<extended>
+ * @covers \AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurredEvent<extended>
  */
 class LoopErrorOccurredTest extends AbstractEventTestCase
 {
@@ -27,14 +27,14 @@ class LoopErrorOccurredTest extends AbstractEventTestCase
     /**
      * @var string
      */
-    protected $event_class = LoopErrorOccurred::class;
+    protected $event_class = LoopErrorOccurredEvent::class;
 
     /**
      * {@inheritdoc}
      */
     public function testConstructor(): void
     {
-        $event = new LoopErrorOccurred(
+        $event = new LoopErrorOccurredEvent(
             $this->app,
             $request = new ServerRequest,
             $exception = new \Exception('foo')

--- a/tests/Events/LoopErrorOccurredTest.php
+++ b/tests/Events/LoopErrorOccurredTest.php
@@ -37,7 +37,7 @@ class LoopErrorOccurredTest extends AbstractEventTestCase
         $event = new LoopErrorOccurred(
             $this->app,
             $request = new ServerRequest,
-            $exception = new \Exception("foo")
+            $exception = new \Exception('foo')
         );
 
         $this->assertSame($this->app, $event->application());

--- a/tests/Events/LoopErrorOccurredTest.php
+++ b/tests/Events/LoopErrorOccurredTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Tests\Events;
+
+use Zend\Diactoros\ServerRequest;
+use AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurred;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithException;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithServerRequest;
+
+/**
+ * @covers \AvtoDev\RoadRunnerLaravel\Events\LoopErrorOccurred<extended>
+ */
+class LoopErrorOccurredTest extends AbstractEventTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected $required_interfaces = [
+        WithApplication::class,
+        WithException::class,
+        WithServerRequest::class,
+    ];
+
+    /**
+     * @var string
+     */
+    protected $event_class = LoopErrorOccurred::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testConstructor(): void
+    {
+        $event = new LoopErrorOccurred(
+            $this->app,
+            $request = new ServerRequest,
+            $exception = new \Exception("foo")
+        );
+
+        $this->assertSame($this->app, $event->application());
+        $this->assertSame($exception, $event->exception());
+        $this->assertSame($request, $event->serverRequest());
+    }
+}

--- a/tests/Listeners/SendExceptionToStderrListenerTest.php
+++ b/tests/Listeners/SendExceptionToStderrListenerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Tests\Listeners;
+
+use AvtoDev\RoadRunnerLaravel\Listeners\SendExceptionToStderrListener;
+
+/**
+ * @covers \AvtoDev\RoadRunnerLaravel\Listeners\SendExceptionToStderrListener<extended>
+ */
+class SendExceptionToStderrListenerTest extends AbstractListenerTestCase
+{
+    public function testHandle(): void
+    {
+        $this->listenerFactory()->handle(new \stdClass);
+
+        $this->markTestIncomplete('There is no legal way for handle method testing.');
+    }
+
+    protected function listenerFactory()
+    {
+        return new SendExceptionToStderrListener;
+    }
+}

--- a/tests/Listeners/StopWorkerListenerTest.php
+++ b/tests/Listeners/StopWorkerListenerTest.php
@@ -15,15 +15,7 @@ use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
 class StopWorkerListenerTest extends AbstractListenerTestCase
 {
     /**
-     * @inheritDoc
-     */
-    protected function listenerFactory()
-    {
-        return new StopWorkerListener;
-    }
-
-    /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function testHandle(): void
     {
@@ -53,5 +45,13 @@ class StopWorkerListenerTest extends AbstractListenerTestCase
             ->getMock();
 
         $this->listenerFactory()->handle($event_mock);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function listenerFactory()
+    {
+        return new StopWorkerListener;
     }
 }

--- a/tests/Listeners/StopWorkerListenerTest.php
+++ b/tests/Listeners/StopWorkerListenerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\RoadRunnerLaravel\Tests\Listeners;
+
+use Mockery as m;
+use Spiral\RoadRunner\PSR7Client;
+use AvtoDev\RoadRunnerLaravel\Listeners\StopWorkerListener;
+use AvtoDev\RoadRunnerLaravel\Events\Contracts\WithApplication;
+
+/**
+ * @covers \AvtoDev\RoadRunnerLaravel\Listeners\StopWorkerListener<extended>
+ */
+class StopWorkerListenerTest extends AbstractListenerTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function listenerFactory()
+    {
+        return new StopWorkerListener;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testHandle(): void
+    {
+        $worker = m::mock()->shouldReceive('stop')->once()->getMock();
+
+        $psr7_client_mock = new class($worker) {
+            protected $worker;
+
+            public function __construct($worker)
+            {
+                $this->worker = $worker;
+            }
+
+            public function getWorker()
+            {
+                return $this->worker;
+            }
+        };
+
+        $this->app->instance(PSR7Client::class, $psr7_client_mock);
+
+        $event_mock = m::mock(WithApplication::class)
+            ->makePartial()
+            ->expects('application')
+            ->once()
+            ->andReturn($this->app)
+            ->getMock();
+
+        $this->listenerFactory()->handle($event_mock);
+    }
+}

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -203,7 +203,7 @@ class WorkerTest extends AbstractTestCase
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
             ->withArgs($this->getAfterBootstrapClosure())
-            ->withArgs($this->mockEventsClosure($fired_events))
+            ->withArgs($this->getMockEventsClosure($fired_events))
             ->passthru()
             ->getMock();
 
@@ -270,7 +270,7 @@ class WorkerTest extends AbstractTestCase
             ->andReturnTrue()
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
-            ->withArgs($this->mockEventsClosure($fired_events))
+            ->withArgs($this->getMockEventsClosure($fired_events))
             ->passthru()
             ->getMock();
 
@@ -298,7 +298,7 @@ class WorkerTest extends AbstractTestCase
             Events\LoopErrorOccurredEvent::class,
         ];
 
-        $event_closure = $this->mockEventsClosure($fired_events);
+        $event_closure = $this->getMockEventsClosure($fired_events);
 
         /** @var m\MockInterface|Worker $worker */
         $worker = m::mock(Worker::class, [$this->base_dir])
@@ -457,7 +457,7 @@ class WorkerTest extends AbstractTestCase
      *
      * @return \Closure
      */
-    private function mockEventsClosure(&$fired_events)
+    private function getMockEventsClosure(&$fired_events): callable
     {
         return static function (Application $app) use (&$fired_events): bool {
             $app->instance(

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -18,6 +18,7 @@ use AvtoDev\RoadRunnerLaravel\ServiceProvider;
 use AvtoDev\RoadRunnerLaravel\WorkerInterface;
 use Illuminate\Contracts\Foundation\Application;
 use Spiral\RoadRunner\Diactoros\ServerRequestFactory;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 
 /**
  * Important note: when you catch mockery errors like `Method respond(<MultiArgumentClosure===true>) from ...`
@@ -182,8 +183,6 @@ class WorkerTest extends AbstractTestCase
             Events\BeforeRequestHandlingEvent::class,
         ];
 
-        // @todo: @jetexe We need to disable all event listeners
-
         /** @var m\MockInterface|Worker $worker */
         $worker = m::mock(Worker::class, [$this->base_dir])
             ->makePartial()
@@ -204,30 +203,7 @@ class WorkerTest extends AbstractTestCase
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
             ->withArgs($this->getAfterBootstrapClosure())
-            ->withArgs(static function (Application $app) use (&$fired_events): bool {
-                $app->instance(
-                    'events',
-                    m::mock($app->make('events'))
-                        ->shouldReceive('dispatch')
-                        ->withArgs(static function ($event) use (&$fired_events): bool {
-                            $event_class = \is_object($event)
-                                ? \get_class($event)
-                                : (string) $event;
-
-                            if (! isset($fired_events[$event_class])) {
-                                $fired_events[$event_class] = 1;
-                            } else {
-                                $fired_events[$event_class]++;
-                            }
-
-                            return true;
-                        })
-                        ->passthru()
-                        ->getMock()
-                );
-
-                return true;
-            })
+            ->withArgs($this->mockEventsClosure($fired_events))
             ->passthru()
             ->getMock();
 
@@ -251,6 +227,13 @@ class WorkerTest extends AbstractTestCase
      */
     public function testWorkerErrorHandling(): void
     {
+        /** @var int[] $fired_events Key is event class, value - firing count */
+        $fired_events = [];
+
+        $expected_events = [
+            Events\LoopErrorOccurredEvent::class,
+        ];
+
         $psr_worker = (new PSR7Client($this->rr_worker))->getWorker();
 
         /** @var m\MockInterface|Worker $worker */
@@ -287,11 +270,88 @@ class WorkerTest extends AbstractTestCase
             ->andReturnTrue()
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
-            ->withArgs($this->getAfterBootstrapClosure())
+            ->withArgs($this->mockEventsClosure($fired_events))
             ->passthru()
             ->getMock();
 
         $worker->start();
+
+        foreach ($expected_events as $expected_event) {
+            if (! isset($fired_events[$expected_event])) {
+                $this->fail("Event [{$expected_event}] was not fired");
+            } else {
+                $this->assertSame(
+                    1,
+                    $fired_events[$expected_event],
+                    "Event [{$expected_event}] was fired {$fired_events[$expected_event]} times (instead once)"
+                );
+            }
+        }
+    }
+
+    public function testWorkerErrorHandlingAfterRespond(): void
+    {
+        /** @var int[] $fired_events Key is event class, value - firing count */
+        $fired_events = [];
+
+        $expected_events = [
+            Events\LoopErrorOccurredEvent::class,
+        ];
+
+        $event_closure = $this->mockEventsClosure($fired_events);
+
+        /** @var m\MockInterface|Worker $worker */
+        $worker = m::mock(Worker::class, [$this->base_dir])
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->expects('createPsr7Client')
+            ->andReturn(
+                m::mock(PSR7Client::class, [$this->rr_worker])
+                    ->makePartial()
+                    ->shouldReceive('acceptRequest')
+                    ->twice()
+                    ->andReturnUsing($this->getOnceRequestGenerationClosure())
+                    ->getMock()
+                    ->shouldReceive('respond')
+                    ->once()
+                    ->withArgs($this->getHtmlResponseValidationClosure())
+                    ->getMock()
+                    ->shouldReceive('getWorker')
+                    ->andReturn(
+                        m::mock()
+                            ->shouldNotReceive('error') // <-- important
+                            ->getMock()
+                    )
+                    ->getMock()
+            )
+            ->getMock()
+            ->shouldReceive('preResolveApplicationAbstracts')
+            ->withArgs(static function (Application $app) use ($event_closure): bool {
+                $event_closure($app);
+                $app->instance(HttpKernelContract::class, m::mock($app->make(HttpKernelContract::class))
+                    ->makePartial()
+                    ->shouldReceive('terminate')
+                    ->once()
+                    ->andThrow(new \RuntimeException('Muted exception'))
+                    ->getMock());
+
+                return true;
+            })
+            ->getMock();
+
+        $worker->start();
+
+        foreach ($expected_events as $expected_event) {
+            if (! isset($fired_events[$expected_event])) {
+                $this->fail("Event [{$expected_event}] was not fired");
+            } else {
+                $this->assertSame(
+                    1,
+                    $fired_events[$expected_event],
+                    "Event [{$expected_event}] was fired {$fired_events[$expected_event]} times (instead once)"
+                );
+            }
+        }
     }
 
     /**
@@ -385,6 +445,40 @@ class WorkerTest extends AbstractTestCase
             $this->assertSame(200, $response->getStatusCode());
             $this->assertNotEmpty($response->getHeaders());
             $this->assertContains('<html', Str::lower((string) $response->getBody()));
+
+            return true;
+        };
+    }
+
+    /**
+     * Use this closure if you want to mute any fired events.
+     *
+     * @param $fired_events
+     *
+     * @return \Closure
+     */
+    private function mockEventsClosure(&$fired_events)
+    {
+        return static function (Application $app) use (&$fired_events): bool {
+            $app->instance(
+                'events',
+                m::mock($app->make('events'))
+                    ->shouldReceive('dispatch')
+                    ->withArgs(static function ($event) use (&$fired_events): bool {
+                        $event_class = \is_object($event)
+                            ? \get_class($event)
+                            : (string) $event;
+
+                        if (! isset($fired_events[$event_class])) {
+                            $fired_events[$event_class] = 1;
+                        } else {
+                            $fired_events[$event_class]++;
+                        }
+
+                        return true;
+                    })
+                    ->getMock()
+            );
 
             return true;
         };

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -182,6 +182,8 @@ class WorkerTest extends AbstractTestCase
             Events\BeforeRequestHandlingEvent::class,
         ];
 
+        // @todo: @jetexe We need to disable all event listeners
+
         /** @var m\MockInterface|Worker $worker */
         $worker = m::mock(Worker::class, [$this->base_dir])
             ->makePartial()
@@ -280,6 +282,9 @@ class WorkerTest extends AbstractTestCase
                     )
                     ->getMock()
             )
+            ->getMock()
+            ->shouldReceive('isDebugModeEnabled')
+            ->andReturnTrue()
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
             ->withArgs($this->getAfterBootstrapClosure())

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace AvtoDev\RoadRunnerLaravel\Tests;
 
-use Illuminate\Support\Facades\App;
 use Mockery as m;
 use RuntimeException;
 use Illuminate\Support\Str;
@@ -270,12 +269,12 @@ class WorkerTest extends AbstractTestCase
             )
             ->getMock()
             ->shouldReceive('preResolveApplicationAbstracts')
-            ->withArgs(static function (Application $app) use ($mock_event_closure):bool{
+            ->withArgs(static function (Application $app) use ($mock_event_closure): bool {
                 $mock_event_closure($app);
 
                 $config = $app->make('config');
 
-                $config->set('app.debug',true);
+                $config->set('app.debug', true);
 
                 return true;
             })


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

### Added

- Event `LoopErrorOccurredEvent` (triggered on request processing exception)
- Listener `SendExceptionToStderrListener` for direct exception sending (as a string) into `stderr`
- Listener `StopWorkerListener` for worker stopping

### Changed

- Default package configuration includes `LoopErrorOccurredEvent` event listeners: `SendExceptionToStderrListener` and `StopWorkerListener`
- When "debug mode" (`app.debug`) is **not** enabled - client will get only `Internal server error` string instead exception with stacktrace

### Fixed

- Double response sending on request processing error (calling `$psr7_client->respond` and `$psr7_client->getWorker()->error` after that)

Fixes #42

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/roadrunner-laravel/blob/master/CHANGELOG.md) file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
